### PR TITLE
Add Go 1.13 support demo files

### DIFF
--- a/.idea/documentation-code-examples.iml
+++ b/.idea/documentation-code-examples.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,10 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
+      <option name="processCode" value="true" />
+      <option name="processLiterals" value="true" />
+      <option name="processComments" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+  <component name="ProjectInspectionProfilesVisibleTreeState">
+    <entry key="Project Default">
+      <profile-state>
+        <expanded-state>
+          <State />
+          <State>
+            <id>GeneralGo</id>
+          </State>
+          <State>
+            <id>Go</id>
+          </State>
+          <State>
+            <id>Probable bugsGo</id>
+          </State>
+        </expanded-state>
+        <selected-state>
+          <State>
+            <id>GoNilness</id>
+          </State>
+        </selected-state>
+      </profile-state>
+    </entry>
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/documentation-code-examples.iml" filepath="$PROJECT_DIR$/.idea/documentation-code-examples.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/GoSupport/1.13/numliterals.go
+++ b/GoSupport/1.13/numliterals.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+func shiftDemo(shift int) {
+	x := 42
+	result := x << shift
+	fmt.Printf("shifting %d by %d results in %d\n", x, shift, result)
+}
+
+func main() {
+	shiftDemo(0)
+	shiftDemo(1)
+}

--- a/GoSupport/1.13/shiftcounts.go
+++ b/GoSupport/1.13/shiftcounts.go
@@ -1,0 +1,10 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Printf("binary number: %d\n", 0b100)
+	fmt.Printf("octal number: %d\n", 0o427)
+	fmt.Printf("hexadecimal numbers: %g and %g\n", 0x1p2, 0x1p-2)
+	fmt.Printf("number with separators: %d\n", 1_000_000)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module documentation-code-examples
+
+go 1.13

--- a/goTemplates/page.html
+++ b/goTemplates/page.html
@@ -1,6 +1,6 @@
 <html lang="en">
 <body>
-{{-/*gotype: documentation-code-examples/html_template.PageData*/-}}
+{{- /*gotype: documentation-code-examples/goTemplates.Data*/ -}}
 {{$pageData := .}}
 </body>
 </html>

--- a/miniDumpDebugging/go.mod
+++ b/miniDumpDebugging/go.mod
@@ -1,1 +1,3 @@
-module "documentation-code-examples/miniDumpDebugging"
+module documentation-code-examples/miniDumpDebugging
+
+go 1.12


### PR DESCRIPTION
This commit adds:
- Go 1.13 support demo files
- fixes the Go Templates example
- creates the `go.mod` file necessary for the Go Templates to work
- the `.idea` folder files that can be shared so that it's easier to get started with the project for others